### PR TITLE
Provide product_info non-existent feature bypass

### DIFF
--- a/1_Installer_Files/includes/modules/pages/product_info/jscript_zen_colorbox.php
+++ b/1_Installer_Files/includes/modules/pages/product_info/jscript_zen_colorbox.php
@@ -17,16 +17,18 @@ if (ZEN_COLORBOX_STATUS == 'true') {
   jQuery(function($) {
   // Quantity Discounts Available
   var discountPriceLink = $('a[href*="popupWindowPrice"]');
-  var discountPriceUrl = discountPriceLink.attr('href').match(/'(.*?)'/)[1];
-  discountPriceLink.attr({
-    'href':'#'
-  }).colorbox({
-    'href':discountPriceUrl,
-    width: '550px',
-    onComplete: function(){
-      $('#cboxLoadedContent').find('a[href*="window.close"]').closest('td').hide();
-    }
-  });
+  if (discountPriceLink.length != 0) {
+    var discountPriceUrl = discountPriceLink.attr('href').match(/'(.*?)'/)[1];
+    discountPriceLink.attr({
+      'href':'#'
+    }).colorbox({
+      'href':discountPriceUrl,
+      width: '550px',
+      onComplete: function(){
+        $('#cboxLoadedContent').find('a[href*="window.close"]').closest('td').hide();
+      }
+    });
+  }
 });
 
 </script>


### PR DESCRIPTION
The code of the pages/product-info javascript was updated to include some additional features; however, for systems that do not have the associated/sought code, javascript errors occur.  The code added to this commit is intended to prevent the javascript error, but also to allow the new code to continue to function.

Discussed in issue #9 (https://github.com/daniel-hopkins/zen-colorbox/issues/9)