### PR TITLE
V2.1.3 rel to data colorbox

### DIFF
--- a/1_Installer_Files/includes/classes/zen_colorbox/autoload_default.php
+++ b/1_Installer_Files/includes/classes/zen_colorbox/autoload_default.php
@@ -10,7 +10,7 @@
  */
 ?>
 jQuery(function($) {
-	$("a[rel^='colorbox']").colorbox({<?php require(DIR_FS_CATALOG . DIR_WS_CLASSES . 'zen_colorbox/options.php'); ?>});;
+	$("a[data-colorbox^='colorbox']").colorbox({<?php require(DIR_FS_CATALOG . DIR_WS_CLASSES . 'zen_colorbox/options.php'); ?>});;
   // Disable Colobox on main reviews page image
-  $("#productMainImageReview a").removeAttr("rel");
+  $("#productMainImageReview a").removeAttr("data-colorbox");
 });

--- a/1_Installer_Files/includes/classes/zen_colorbox/autoload_default.php
+++ b/1_Installer_Files/includes/classes/zen_colorbox/autoload_default.php
@@ -11,6 +11,6 @@
 ?>
 jQuery(function($) {
 	$("a[data-colorbox^='colorbox']").colorbox({<?php require(DIR_FS_CATALOG . DIR_WS_CLASSES . 'zen_colorbox/options.php'); ?>});;
-  // Disable Colobox on main reviews page image
+  // Disable Colorbox on main reviews page image
   $("#productMainImageReview a").removeAttr("data-colorbox");
 });

--- a/1_Installer_Files/includes/modules/YOUR_TEMPLATE/zen_colorbox.php
+++ b/1_Installer_Files/includes/modules/YOUR_TEMPLATE/zen_colorbox.php
@@ -11,11 +11,11 @@
 
 if (ZEN_COLORBOX_STATUS == 'true') {
     if (ZEN_COLORBOX_GALLERY_MODE == 'true') {
-      $rel = 'colorbox';
+      $data_colorbox = 'colorbox';
     } else {
-      $rel = 'colorbox-' . rand(100, 999);
+      $data_colorbox = 'colorbox-' . rand(100, 999);
     }
-    $script_link = '<script type="text/javascript"><!--' . "\n" . 'document.write(\'' . ($flag_display_large ? '<a href="' . zen_colorbox($products_image_large, addslashes($products_name), defined('LARGE_IMAGE_WIDTH') ? LARGE_IMAGE_WIDTH : '', defined('LARGE_IMAGE_HEIGHT') ? LARGE_IMAGE_HEIGHT : '') . '" rel="' . $rel . '" title="' . zen_output_string_protected($products_name) . '">' . $thumb_slashes . '<br \/>' . TEXT_CLICK_TO_ENLARGE . '<\/a>' : $thumb_slashes) . '\');' . "\n" . '//--></script>';
+    $script_link = '<script type="text/javascript"><!--' . "\n" . 'document.write(\'' . ($flag_display_large ? '<a href="' . zen_colorbox($products_image_large, addslashes($products_name), defined('LARGE_IMAGE_WIDTH') ? LARGE_IMAGE_WIDTH : '', defined('LARGE_IMAGE_HEIGHT') ? LARGE_IMAGE_HEIGHT : '') . '" data-colorbox="' . $data_colorbox . '" title="' . zen_output_string_protected($products_name) . '">' . $thumb_slashes . '<br \/>' . TEXT_CLICK_TO_ENLARGE . '<\/a>' : $thumb_slashes) . '\');' . "\n" . '//--></script>';
   } else {
     $script_link = '<script type="text/javascript"><!--' . "\n" . 'document.write(\'' . ($flag_display_large ? '<a href="javascript:popupWindow(\\\'' . str_replace($products_image_large, urlencode(addslashes($products_image_large)), $large_link) . '\\\')">' . $thumb_slashes . '<br \/>' . TEXT_CLICK_TO_ENLARGE . '<\/a>' : $thumb_slashes) . '\');' . "\n" . '//--></script>';
   }

--- a/1_Installer_Files/includes/templates/YOUR_TEMPLATE/templates/tpl_modules_main_product_image.php
+++ b/1_Installer_Files/includes/templates/YOUR_TEMPLATE/templates/tpl_modules_main_product_image.php
@@ -15,13 +15,13 @@
 <?php
 if (function_exists('zen_colorbox') && ZEN_COLORBOX_STATUS == 'true') {
   if (ZEN_COLORBOX_GALLERY_MODE == 'true' && ZEN_COLORBOX_GALLERY_MAIN_IMAGE == 'true') {
-    $rel = 'colorbox';
+    $data_colorbox = 'colorbox';
   } else {
-    $rel = 'colorbox-' . rand(100, 999);
+    $data_colorbox = 'colorbox-' . rand(100, 999);
   }
 ?>
 <script type="text/javascript"><!--
-document.write('<?php echo '<a href="' . zen_colorbox($products_image_large, addslashes($products_name), defined('LARGE_IMAGE_WIDTH') ? LARGE_IMAGE_WIDTH : '', defined('LARGE_IMAGE_HEIGHT') ? LARGE_IMAGE_HEIGHT : '') . '" rel="' . $rel . '" class="' . "nofollow" . '" title="' . zen_output_string_protected($products_name) . '">' . zen_image($products_image_medium, addslashes($products_name), MEDIUM_IMAGE_WIDTH, MEDIUM_IMAGE_HEIGHT) . '<br \/><span class="imgLink">' . TEXT_CLICK_TO_ENLARGE . '<\/span><\/a>'; ?>');
+document.write('<?php echo '<a href="' . zen_colorbox($products_image_large, addslashes($products_name), defined('LARGE_IMAGE_WIDTH') ? LARGE_IMAGE_WIDTH : '', defined('LARGE_IMAGE_HEIGHT') ? LARGE_IMAGE_HEIGHT : '') . '" data-colorbox="' . $data_colorbox . '" class="' . "nofollow" . '" title="' . zen_output_string_protected($products_name) . '">' . zen_image($products_image_medium, addslashes($products_name), MEDIUM_IMAGE_WIDTH, MEDIUM_IMAGE_HEIGHT) . '<br \/><span class="imgLink">' . TEXT_CLICK_TO_ENLARGE . '<\/span><\/a>'; ?>');
 //--></script>
 <?php } else { ?>
 <?php // eof Zen Colorbox 2012-04-30 niestudio ?>


### PR DESCRIPTION
Addresses #19 to replace the html keyword `rel` with `data-colorbox` to support html validation.

Also corrects a long standing typo in a comment changing `Colobox` to `Colorbox`