### PR TITLE
fix for php notice when colorbox is disabled in admin

### DIFF
--- a/1_Installer_Files/YOUR_ADMIN/includes/installers/zen_colorbox/2_1_3.php
+++ b/1_Installer_Files/YOUR_ADMIN/includes/installers/zen_colorbox/2_1_3.php
@@ -31,6 +31,8 @@
   - Changed the html indicator for hooking into this program from rel= to data-cbox-rel=
   - Incorporated a check for 'LARGE_IMAGE_WIDTH' and 'LARGE_IMAGE_HEIGHT' setting to an empty string if not defined.
   - Updated jscript/jquery.colorbox-min.js to support jQuery 3.x.
+  - Added plugin check to ensure that even on upgrade from older versions that in PHP 7.2+ environments that the constant
+      is defined and removal by admin/includes/installers/zen_colorbox/uninstall_zcb.sql is not required.
   
 */
 
@@ -47,6 +49,12 @@ if ($zc150 || $zc130) { // continue Zen Cart 1.5.0 or Zen Cart 1.3.x
     include_once (DIR_FS_CATALOG_LANGUAGES . 'english/zen_colorbox_language.php');
   }
 
+  if (!defined($module_constant . '_PLUGIN_CHECK')) {
+    $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added, use_function, set_function) VALUES
+                          ('" . $module_name . " (Update Check)', '" . $module_constant . "_PLUGIN_CHECK', '" . SHOW_VERSION_UPDATE_IN_HEADER . "', 'Allow version checking if Zen Cart version checking enabled<br/><br/>If false, no version checking performed.<br/>If true, then only if Zen Cart version checking is on:', " . $configuration_group_id . ", 15, NOW(), NULL, 'zen_cfg_select_option(array(\'true\', \'false\'),');");
+    define($module_constant . '_PLUGIN_CHECK', true);
+  }
+  
   $this_files_version = str_replace("_", ".", substr($installer, 0, -1 * $file_extension_len));
   $return_cancel = true;
 

--- a/1_Installer_Files/includes/classes/observers/auto.zen_color_box_observer.php
+++ b/1_Installer_Files/includes/classes/observers/auto.zen_color_box_observer.php
@@ -60,6 +60,7 @@ class zcObserverZenColorBoxObserver extends base {
      *             'products_name' => $products_name,
      *             'products_image_large' => $products_image_large,
      *             'thumb_slashes' => $thumb_slashes,
+     *             'large_link' = $large_link,
      *             'index' => $i
      *         ),
      *         $script_link,
@@ -77,6 +78,7 @@ class zcObserverZenColorBoxObserver extends base {
             $products_name = $paramsArray['products_name'];
             $products_image_large = $paramsArray['products_image_large'];
             $thumb_slashes = $paramsArray['thumb_slashes'];
+            $large_link = $paramsArray['large_link'];
             $i = $paramsArray['index'];
 
             include DIR_WS_MODULES . zen_get_module_directory('zen_colorbox.php');


### PR DESCRIPTION
php 7.3.7, Report All Errors installed for catalog. IH5 installed.
Disable Colorbox in admin
For each additional image:

> PHP Notice:  Undefined variable: large_link in ..\public_html\tienda-156\includes\modules\motorvista5\zen_colorbox.php on line 20

which was (impossible to paste)

![Clipboard01](https://user-images.githubusercontent.com/4391026/62489340-c94a2d00-b7c6-11e9-870d-988018583253.gif)

and so the javascript link was empty.
I found that this file was not passing large_link through the notifier.

Also in the latest /modules/additional_images, this is also missing from the notifier.
But, it **is** expected by the IH5 observer.
